### PR TITLE
Download full git history in CI pipeline

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Lint Code Base
         uses: github/super-linter@v4
         env:


### PR DESCRIPTION
The GitHub Super Linter, which we are using for linting, requires that
the checkout be performed with `fetch-depth: 0` to get the full history
in order to properly fetch changed files. Currently, the Lint workflow
will unexpectedly fail for perfectly valid jobs (as seen in PR #29).
