### PR TITLE
Add HTTP PUT support for OSCAL System Security Plans

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1529,6 +1529,39 @@ paths:
             - write:ssps
             - read:ssps
       x-codegen-request-body-name: body
+    put:
+      tags:
+        - OSCAL System Security Plan
+      summary: Replaces an existing OSCAL system security plan
+      operationId: replaceSsp
+      parameters:
+        - name: sspId
+          in: path
+          description: ID of system security plan to replace.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: System security plan object to be replaced.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OSCALSsp"
+        required: true
+      responses:
+        204:
+          description: Updated system security plan
+        404:
+          description: System security plan not found
+        400:
+          description: Bad Request
+        415:
+          description: Unsupported media type
+      security:
+        - oscal_auth:
+            - write:ssps
+            - read:ssps
+      x-codegen-request-body-name: body
     delete:
       tags:
         - OSCAL System Security Plan


### PR DESCRIPTION
## Motivation
The OSCAL REST API should allow for wholesale replacement of a system security plan (SSP). Clients will want to submit an SSP that may have updates across multiple nested objects. Creating a diff and subsequently an exhaustive list of `PATCH` operations requires significant overhead in maintaining state. This may be unwarranted for simple clients that want to implement high-level operations against an instance of the [OSCAL SSP model](https://pages.nist.gov/OSCAL/concepts/layer/implementation/ssp/).

## Specification
To accommodate the scenario described above, this update adds support the for HTTP `PUT` method under the path:
```
/system-security-plans/{sspId}
```
where `sspId` is the [System Security Plan Universally Unique Identifier](https://pages.nist.gov/OSCAL/reference/latest/system-security-plan/json-reference/#/system-security-plan/uuid). Furthermore, a request body containing the **entire** JSON SSP model is also required to fulfill this request. ~~Lastly, the `UUID` value specified in the body of the request under the JSON path `$.system-security-plan.uuid` is ignored under all circumstances, because the `sspId` specified in URI path takes precedence when aligning with HTTP/1.1 semantics. Since a `UUID` is required to pass schema validation, any `UUID` specified must be accepted, but not processed.~~ 

### HTTP/1.1 Semantics Alignment
Based on quoted sections from the [PUT method definition](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.4), this update also includes sematic alignment for the `PUT` request via HTTP status codes.

#### Success Status Codes
> If the target resource does not have a current representation and the PUT successfully creates one, then the origin server MUST inform the user agent by sending a 201 (Created) response.

~~In the case when the origin (server) cannot find the SSP using the `sspId`, the origin must create a new SSP resource and return a `201` response code. This method is not a replacement for the `POST` method since it is idempotent. To maintain idempotency, the `sspId` specified by the client should be honored by the origin. The method by which an origin handles conflicts of UUIDs is out of scope for this specification.~~

This scenario will not be supported.

> If the target resource does have a current representation and that representation is successfully modified in accordance with the state of the enclosed representation, then the origin server MUST send either a 200 (OK) or a 204 (No Content) response to indicate successful completion of the request.

The origin must return a `204` status code if it modified an existing SSP resource identified by the `sspId`. The `204` status code is preferred over the `200` status code since SSP JSON objects can be large, causing significant network bandwidth usage. Future work may include support for the `200` status code if versioning can be handled correctly.

#### Error Status Codes
> An origin server that allows PUT on a given target resource MUST send a 400 (Bad Request) response to a PUT request that contains a Content-Range header field ([Section 4.2 of [RFC7233]](https://datatracker.ietf.org/doc/html/rfc7233#section-4.2)), since the payload is likely to be partial content that has been mistakenly PUT as a full representation.

- For this reason, a client must submit the **entire** SSP JSON object as part of the request body. `multipart` submissions are not allowed on this endpoint, and the origin must respond with a `400` status code, if the client mistakenly tries to submit such a request. 
- A `400` status code should also be returned in case the JSON that was submitted is malformed.
- If valid JSON was submitted, but the JSON object fails semantic validation (i.e. validation against the [OSCAL JSON SSP schema](https://pages.nist.gov/OSCAL/reference/latest/system-security-plan/json-outline/)) a `400` status code must be returned by the origin.

> When a PUT representation is inconsistent with the target resource, the origin server SHOULD either make them consistent, by transforming the representation or changing the resource configuration, or respond with an appropriate error message containing sufficient information to explain why the representation is unsuitable.  The 409 (Conflict) or 415 (Unsupported Media Type) status codes are suggested, with the latter being specific to constraints on Content-Type values.

- The origin should return a `415` status code if the `Content-Type` header is not `application/json`. Per [Section 3.1.1.5 of [RFC7231]](https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.5), the origin may infer the media type if it is not specified to improve compatibility. However, if deemed incompatible the `415` status code must be returned.

## Future Considerations
- Adding support for `ETag` and `Last-Modified` based [Section 4.3.4 of [RFC7231]](https://www.rfc-editor.org/rfc/rfc7231.html#section-4.3.4). This should be carefully aligned with the [`metadata`](https://pages.nist.gov/OSCAL/reference/latest/system-security-plan/json-reference/#/system-security-plan/metadata) properties of an SSP.
- Adding support for the `409` error status code. This status code was intentionally left out since it requires a rigorous implementation of version tracking. Since version tracking itself is a consideration for future improvement, supporting the `409` status code cannot be accommodated.
- Adding support for the `422` error status code. While the `422` error status code is not part of RFC 7231, it is part of the draft [HTTP Semantics](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-semantics-19) standard. If approved, support for this error code, will enable clients to improve error handling.

## References
- [RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content](https://datatracker.ietf.org/doc/html/rfc7231)
- [OSCAL SSP model](https://pages.nist.gov/OSCAL/concepts/layer/implementation/ssp/)
- [System Security Plan Model v1.0.1 JSON Format Reference](https://pages.nist.gov/OSCAL/reference/latest/system-security-plan/json-reference/#/system-security-plan/)
- [PUT - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT)
- https://github.com/EasyDynamics/easygrc/issues/23