### PR TITLE
Add HTTP PUT support for OSCAL Catalogs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -203,6 +203,39 @@ paths:
             - write:catalogs
             - read:catalogs
       x-codegen-request-body-name: body
+    put:
+      tags:
+        - OSCAL Catalog
+      summary: Replaces an existing OSCAL catalog
+      operationId: replaceCatalog
+      parameters:
+        - name: catalogId
+          in: path
+          description: ID of catalog to replace.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Catalog object to be replaced.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OSCALCatalog"
+        required: true
+      responses:
+        204:
+          description: Updated catalog
+        404:
+          description: Catalog not found
+        400:
+          description: Bad Request
+        415:
+          description: Unsupported media type
+      security:
+        - oscal_auth:
+            - write:catalogs
+            - read:catalogs
+      x-codegen-request-body-name: body
     delete:
       tags:
         - OSCAL Catalog


### PR DESCRIPTION
## Motivation
Similar to the capability described in #42, the OSCAL REST API should allow for a full replacement of an [OSCAL Catalog](https://pages.nist.gov/OSCAL/concepts/layer/control/catalog/).

## Specification
To accommodate the scenario described above, this update adds support for the following HTTP PUT request:
```
PUT /catalogs/{catalogId}
Content-Type: application/json

{
  "catalog": {
      "uuid": "{catalogId}"
      ...
   }
}
```
where `catalogId` is the [Catalog Universally Unique Identifier](https://pages.nist.gov/OSCAL/reference/latest/catalog/json-reference/#/catalog/uuid), and the request body is a wrapped JSON object that conforms to the [Catalog Model](https://pages.nist.gov/OSCAL/reference/latest/catalog/json-outline/).

### Success Codes
- `204` : The catalog is successfully updated by the origin server.
### Error Codes
- `404`: Catalog not found. The origin server must return this error code when the resource hosted at the path `catalogs/{catalogId}` cannot be found. 

- `400`: Bad Request. The origin must respond with this error code:
  - When a client tries to submit a `multipart` request
  - When the `catalogId` in the path does not match the `catalogId` in the request body
  - If the JSON object that was submitted as part of the request body was malformed
  - If the the JSON object that was submitted as part of the request body fails semantic validation
 
- `415`: Unsupported media type. If the content that was submitted is cannot be interpreted as the `application/json` media type by the origin server.

## References
- [Add HTTP PUT support for OSCAL System Security Plans](https://github.com/EasyDynamics/oscal-rest/pull/42)
- [OSCAL Catalog Model](https://pages.nist.gov/OSCAL/reference/latest/catalog/)
- [JSON Source Editor](https://github.com/EasyDynamics/easygrc/issues/23)