### PR TITLE
Add HTTP PUT support for OSCAL Profiles

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -387,6 +387,39 @@ paths:
       security:
         - oscal_auth:
             - read:profiles
+    put:
+      tags:
+        - OSCAL Profile
+      summary: Replaces an existing OSCAL profile
+      operationId: replaceProfile
+      parameters:
+        - name: profileId
+          in: path
+          description: ID of profile to replace.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Profile object to be replaced.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OSCALProfile"
+        required: true
+      responses:
+        204:
+          description: Updated profile
+        404:
+          description: Profile not found
+        400:
+          description: Bad Request
+        415:
+          description: Unsupported media type
+      security:
+        - oscal_auth:
+            - write:profiles
+            - read:profiles
+      x-codegen-request-body-name: body
     delete:
       tags:
         - OSCAL Profile


### PR DESCRIPTION
## Motivation
Similar to the capability described in #42, the OSCAL REST API should allow for a full replacement of an [OSCAL Profile](https://pages.nist.gov/OSCAL/concepts/layer/control/profile/).

## Specification
To accommodate the scenario described above, this update adds support for the following HTTP PUT request:
```
PUT /profiles/{profileId}
Content-Type: application/json

{
  "profile": {
      "uuid": "{profileId}"
      ...
   }
}
```
where `profileId` is the [Profile Universally Unique Identifier](https://pages.nist.gov/OSCAL/reference/latest/profile/json-reference/#/profile/uuid), and the request body is a wrapped JSON object that conforms to the [Profile Model](https://pages.nist.gov/OSCAL/reference/latest/profile/json-outline/).

### Success Codes
- `204` : The profile is successfully updated by the origin server.
### Error Codes
- `404`: Profile not found. The origin server must return this error code when the resource hosted at the path `profiles/{profileId}` cannot be found. 

- `400`: Bad Request. The origin must respond with this error code:
  - When a client tries to submit a `multipart` request
  - When the `profileId` in the path does not match the `profileId` in the request body
  - If the JSON object that was submitted as part of the request body was malformed
  - If the the JSON object that was submitted as part of the request body fails semantic validation
 
- `415`: Unsupported media type. If the content that was submitted is cannot be interpreted as the `application/json` media type by the origin server.

## References
- [Add HTTP PUT support for OSCAL System Security Plans](https://github.com/EasyDynamics/oscal-rest/pull/42)
- [OSCAL Profile Model](https://pages.nist.gov/OSCAL/reference/latest/profile/)
- https://github.com/EasyDynamics/easygrc/issues/23