### PR TITLE
Add HTTP PUT support for OSCAL Component Definitions

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -223,8 +223,12 @@ paths:
               $ref: "#/components/schemas/OSCALCatalog"
         required: true
       responses:
-        204:
+        200:
           description: Updated catalog
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OSCALCatalog"
         404:
           description: Catalog not found
         400:
@@ -407,8 +411,12 @@ paths:
               $ref: "#/components/schemas/OSCALProfile"
         required: true
       responses:
-        204:
+        200:
           description: Updated profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OSCALProfile"
         404:
           description: Profile not found
         400:
@@ -972,6 +980,43 @@ paths:
         405:
           description: Validation exception
           content: {}
+      security:
+        - oscal_auth:
+            - write:componentDefinitions
+            - read:componentDefinitions
+      x-codegen-request-body-name: body
+    put:
+      tags:
+        - OSCAL Component Definition
+      summary: Replaces an existing OSCAL component definition
+      operationId: replaceComponentDefinition
+      parameters:
+        - name: componentDefinitionId
+          in: path
+          description: ID of component definition to replace.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Component definition object to be replaced.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OSCALComponentDefinition"
+        required: true
+      responses:
+        200:
+          description: Updated component definition
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OSCALComponentDefinition"
+        404:
+          description: Component definition not found
+        400:
+          description: Bad Request
+        415:
+          description: Unsupported media type
       security:
         - oscal_auth:
             - write:componentDefinitions
@@ -1615,8 +1660,12 @@ paths:
               $ref: "#/components/schemas/OSCALSsp"
         required: true
       responses:
-        204:
+        200:
           description: Updated system security plan
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OSCALSsp"
         404:
           description: System security plan not found
         400:


### PR DESCRIPTION
## Motivation
Similar to the capability described in #42, the OSCAL REST API should allow for a full replacement of an [OSCAL Component Definition](https://pages.nist.gov/OSCAL/concepts/layer/implementation/component-definition/).

## Specification
To accommodate the scenario described above, this update adds support for the following HTTP PUT request:
```
PUT /component-definitions/{componentDefinitionId}
Content-Type: application/json

{
  "component-definition": {
      "uuid": "{componentDefinitionId}"
      ...
   }
}
```
where `componentDefinitionId` is the [Component Definition Universally Unique Identifier](https://pages.nist.gov/OSCAL/reference/latest/component-definition/json-reference/#/component-definition/uuid), and the request body is a wrapped JSON object that conforms to the [Component Definition Model](https://pages.nist.gov/OSCAL/reference/latest/component-definition/json-outline/).

### Success Codes
- ~~`204` : The component definition is successfully updated by the origin server.~~
- `200`: The The component definition is successfully updated by the origin server, and returned as part of the response. 
### Error Codes
- `404`: Component Definition not found. The origin server must return this error code when the resource hosted at the path `/component-definitions/{componentDefinitionId}` cannot be found. 

- `400`: Bad Request. The origin must respond with this error code:
  - When a client tries to submit a `multipart` request
  - When the `componentDefinitionId` in the path does not match the `componentDefinitionId` in the request body
  - If the JSON object that was submitted as part of the request body was malformed
  - If the the JSON object that was submitted as part of the request body fails semantic validation
 
- `415`: Unsupported media type. If the content that was submitted is cannot be interpreted as the `application/json` media type by the origin server.

## References
- [Add HTTP PUT support for OSCAL System Security Plans](https://github.com/EasyDynamics/oscal-rest/pull/42)
- [OSCAL Component Definition Model](https://pages.nist.gov/OSCAL/reference/latest/component-definition/)
- https://github.com/EasyDynamics/easygrc/issues/23