### PR TITLE
Add PUT and POST Endpoints for SSP Implemented Requirement

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1865,6 +1865,14 @@ paths:
           schema:
             type: string
       responses:
+        201:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/OSCALImplementedRequirement"
         400:
           description: Invalid ID supplied
           content: {}
@@ -1902,6 +1910,12 @@ paths:
           schema:
             type: string
       responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                  $ref: "#/components/schemas/OSCALImplementedRequirement"
         400:
           description: Invalid ID supplied
           content: {}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1844,6 +1844,34 @@ paths:
         - oscal_auth:
             - write:ssps
             - read:ssps
+  /system-security-plans/{sspId}/control-implementation/implemented-requirements:
+    post:
+      tags:
+        - OSCAL System Security Plan
+      summary: Add an implemented requirement to an OSCAL system security plan
+      operationId: addImplementedRequirementToSsp
+      parameters:
+        - name: api_key
+          in: header
+          schema:
+            type: string
+        - name: sspId
+          in: path
+          description: System security plan ID
+          required: true
+          schema:
+            type: string
+      responses:
+        400:
+          description: Invalid ID supplied
+          content: {}
+        404:
+          description: System security plan not found
+          content: {}
+      security:
+        - oscal_auth:
+            - write:ssps
+            - read:ssps
   /system-security-plans/{sspId}/control-implementation/implemented-requirements/{implementedRequirementID}:
     put:
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1844,6 +1844,40 @@ paths:
         - oscal_auth:
             - write:ssps
             - read:ssps
+  /system-security-plans/{sspId}/control-implementation/implemented-requirements/{implementedRequirementID}:
+    put:
+      tags:
+        - OSCAL System Security Plan
+      summary: Updates the body of an implemented requirement in an OSCAL system security plan
+      operationId: updateImplementedRequirementOfSsp
+      parameters:
+        - name: api_key
+          in: header
+          schema:
+            type: string
+        - name: sspId
+          in: path
+          description: System security plan ID
+          required: true
+          schema:
+            type: string
+        - name: implementedRequirementID
+          in: path
+          description: ID of implemented requirement to be updated
+          required: true
+          schema:
+            type: string
+      responses:
+        400:
+          description: Invalid ID supplied
+          content: {}
+        404:
+          description: System security plan or implemented requirement not found
+          content: {}
+      security:
+        - oscal_auth:
+            - write:ssps
+            - read:ssps
   /system-security-plans/search:
     get:
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2173,7 +2173,7 @@ components:
     OSCALImplementedRequirement:
       type: object
       $ref:
-        "https://raw.githubusercontent.com/usnistgov/OSCAL/main/json/schema/oscal_ssp_schema.json#assembly_oscal-ssp_implemented-requirement"
+        "https://raw.githubusercontent.com/EasyDynamics/OSCAL/main/json/schema/oscal_ssp_schema.json#assembly_oscal-ssp_implemented-requirement"
     OSCALRole:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1879,7 +1879,7 @@ paths:
         - oscal_auth:
             - write:ssps
             - read:ssps
-  /system-security-plans/{sspId}/control-implementation/implemented-requirements/{implementedRequirementID}:
+  /system-security-plans/{sspId}/control-implementation/implemented-requirements/{implementedRequirementId}:
     put:
       tags:
         - OSCAL System Security Plan
@@ -1903,7 +1903,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: implementedRequirementID
+        - name: implementedRequirementId
           in: path
           description: ID of implemented requirement to be updated
           required: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1858,10 +1858,6 @@ paths:
               $ref: "#/components/schemas/OSCALImplementedRequirement"
         required: true
       parameters:
-        - name: api_key
-          in: header
-          schema:
-            type: string
         - name: sspId
           in: path
           description: System security plan ID
@@ -1893,10 +1889,6 @@ paths:
               $ref: "#/components/schemas/OSCALImplementedRequirement"
         required: true
       parameters:
-        - name: api_key
-          in: header
-          schema:
-            type: string
         - name: sspId
           in: path
           description: System security plan ID

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2172,8 +2172,10 @@ components:
           $ref: "#/components/schemas/OSCALPartialUpdateExample"
     OSCALImplementedRequirement:
       type: object
-      $ref:
-        "https://raw.githubusercontent.com/EasyDynamics/OSCAL/main/json/schema/oscal_ssp_schema.json#assembly_oscal-ssp_implemented-requirement"
+      properties:
+        implemented-requirement:
+          $ref:
+            "https://raw.githubusercontent.com/EasyDynamics/OSCAL/json-schema-ref-by-path/json/schema/oscal_ssp_schema.json#/definitions/assembly_oscal-ssp_implemented-requirement"
     OSCALRole:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1887,7 +1887,7 @@ paths:
     put:
       tags:
         - OSCAL System Security Plan
-      summary: Updates the body of an implemented requirement in an OSCAL system security plan
+      summary: Updates an implemented requirement in an OSCAL system security plan
       operationId: updateImplementedRequirementOfSsp
       requestBody:
         description: Implemented requirement to be updated

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1915,7 +1915,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/OSCALImplementedRequirement"
+                $ref: "#/components/schemas/OSCALImplementedRequirement"
         400:
           description: Invalid ID supplied
           content: {}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1850,6 +1850,13 @@ paths:
         - OSCAL System Security Plan
       summary: Add an implemented requirement to an OSCAL system security plan
       operationId: addImplementedRequirementToSsp
+      requestBody:
+        description: Implemented requirement to be added
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OSCALImplementedRequirement"
+        required: true
       parameters:
         - name: api_key
           in: header
@@ -1878,6 +1885,13 @@ paths:
         - OSCAL System Security Plan
       summary: Updates the body of an implemented requirement in an OSCAL system security plan
       operationId: updateImplementedRequirementOfSsp
+      requestBody:
+        description: Implemented requirement to be updated
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OSCALImplementedRequirement"
+        required: true
       parameters:
         - name: api_key
           in: header
@@ -2150,6 +2164,10 @@ components:
       properties:
         system-security-plan:
           $ref: "#/components/schemas/OSCALPartialUpdateExample"
+    OSCALImplementedRequirement:
+      type: object
+      $ref:
+        "https://raw.githubusercontent.com/usnistgov/OSCAL/main/json/schema/oscal_ssp_schema.json#assembly_oscal-ssp_implemented-requirement"
     OSCALRole:
       type: object
       properties:


### PR DESCRIPTION
Add documentation for a new endpoint for a PUT request that updates
an implemented requirement in an SSP.

Closes EasyDynamics/easygrc#19