### PR TITLE
Add conflict status to OpenAPI

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -244,14 +244,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OSCALCatalog"
-        404:
-          description: Catalog not found
         400:
           description: Bad Request
-        415:
-          description: Unsupported media type
+        404:
+          description: Catalog not found
         409:
           description: Conflict with current state
+        415:
+          description: Unsupported media type
       security:
         - oscal_auth:
             - write:catalogs
@@ -436,14 +436,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OSCALProfile"
-        404:
-          description: Profile not found
         400:
           description: Bad Request
-        415:
-          description: Unsupported media type
+        404:
+          description: Profile not found
         409:
           description: Conflict with current state
+        415:
+          description: Unsupported media type
       security:
         - oscal_auth:
             - write:profiles
@@ -1040,14 +1040,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OSCALComponentDefinition"
-        404:
-          description: Component definition not found
         400:
           description: Bad Request
-        415:
-          description: Unsupported media type
+        404:
+          description: Component definition not found
         409:
           description: Conflict with current state
+        415:
+          description: Unsupported media type
       security:
         - oscal_auth:
             - write:componentDefinitions
@@ -1705,14 +1705,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OSCALSsp"
-        404:
-          description: System security plan not found
         400:
           description: Bad Request
-        415:
-          description: Unsupported media type
+        404:
+          description: System security plan not found
         409:
           description: Conflict with current state
+        415:
+          description: Unsupported media type
       security:
         - oscal_auth:
             - write:ssps

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -213,7 +213,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          content: {}
       security:
         - oscal_auth:
             - write:catalogs
@@ -355,7 +354,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          content: {}
       security:
         - oscal_auth:
             - write:profiles
@@ -527,7 +525,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          content: {}
       security:
         - oscal_auth:
             - write:profiles
@@ -618,7 +615,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          content: {}
       security:
         - oscal_auth:
             - write:profiles
@@ -765,7 +761,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          content: {}
       security:
         - oscal_auth:
             - write:profiles
@@ -1014,7 +1009,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          content: {}
       security:
         - oscal_auth:
             - write:componentDefinitions
@@ -1191,7 +1185,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          content: {}
       security:
         - oscal_auth:
             - write:componentDefinitions
@@ -1387,7 +1380,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          content: {}
       security:
         - oscal_auth:
             - write:componentDefinitions
@@ -1511,7 +1503,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          conteont: {}
       security:
         - oscal_auth:
             - write:componentDefinitions
@@ -1683,7 +1674,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          content: {}
       security:
         - oscal_auth:
             - write:ssps
@@ -1789,7 +1779,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          content: {}
       security:
         - oscal_auth:
             - write:ssps
@@ -1863,7 +1852,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          content: {}
       security:
         - oscal_auth:
             - write:ssps
@@ -1981,7 +1969,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          content: {}
       security:
         - oscal_auth:
             - write:ssps
@@ -2114,7 +2101,6 @@ paths:
           content: {}
         409:
           description: Conflict with current state
-          content: {}
       security:
         - oscal_auth:
             - write:parties

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -211,6 +211,9 @@ paths:
         405:
           description: Validation exception
           content: {}
+        409:
+          description: Conflict with current state
+          content: {}
       security:
         - oscal_auth:
             - write:catalogs
@@ -248,6 +251,8 @@ paths:
           description: Bad Request
         415:
           description: Unsupported media type
+        409:
+          description: Conflict with current state
       security:
         - oscal_auth:
             - write:catalogs
@@ -348,6 +353,9 @@ paths:
         405:
           description: Validation exception
           content: {}
+        409:
+          description: Conflict with current state
+          content: {}
       security:
         - oscal_auth:
             - write:profiles
@@ -436,6 +444,8 @@ paths:
           description: Bad Request
         415:
           description: Unsupported media type
+        409:
+          description: Conflict with current state
       security:
         - oscal_auth:
             - write:profiles
@@ -514,6 +524,9 @@ paths:
           content: {}
         404:
           description: Profile or catalog not found
+          content: {}
+        409:
+          description: Conflict with current state
           content: {}
       security:
         - oscal_auth:
@@ -602,6 +615,9 @@ paths:
           content: {}
         404:
           description: Profile or import profile not found
+          content: {}
+        409:
+          description: Conflict with current state
           content: {}
       security:
         - oscal_auth:
@@ -746,6 +762,9 @@ paths:
           content: {}
         404:
           description: Profile or party not found
+          content: {}
+        409:
+          description: Conflict with current state
           content: {}
       security:
         - oscal_auth:
@@ -993,6 +1012,9 @@ paths:
         405:
           description: Validation exception
           content: {}
+        409:
+          description: Conflict with current state
+          content: {}
       security:
         - oscal_auth:
             - write:componentDefinitions
@@ -1030,6 +1052,8 @@ paths:
           description: Bad Request
         415:
           description: Unsupported media type
+        409:
+          description: Conflict with current state
       security:
         - oscal_auth:
             - write:componentDefinitions
@@ -1164,6 +1188,9 @@ paths:
           content: {}
         404:
           description: Component definition or party not found
+          content: {}
+        409:
+          description: Conflict with current state
           content: {}
       security:
         - oscal_auth:
@@ -1358,6 +1385,9 @@ paths:
         404:
           description: Component definition not found
           content: {}
+        409:
+          description: Conflict with current state
+          content: {}
       security:
         - oscal_auth:
             - write:componentDefinitions
@@ -1479,6 +1509,9 @@ paths:
         404:
           description: Component definition, component, or control implementation not found
           content: {}
+        409:
+          description: Conflict with current state
+          conteont: {}
       security:
         - oscal_auth:
             - write:componentDefinitions
@@ -1648,6 +1681,9 @@ paths:
         405:
           description: Validation exception
           content: {}
+        409:
+          description: Conflict with current state
+          content: {}
       security:
         - oscal_auth:
             - write:ssps
@@ -1685,6 +1721,8 @@ paths:
           description: Bad Request
         415:
           description: Unsupported media type
+        409:
+          description: Conflict with current state
       security:
         - oscal_auth:
             - write:ssps
@@ -1748,6 +1786,9 @@ paths:
           content: {}
         404:
           description: System security plan or component not found
+          content: {}
+        409:
+          description: Conflict with current state
           content: {}
       security:
         - oscal_auth:
@@ -1819,6 +1860,9 @@ paths:
           content: {}
         404:
           description: System security plan or party not found
+          content: {}
+        409:
+          description: Conflict with current state
           content: {}
       security:
         - oscal_auth:
@@ -1934,6 +1978,9 @@ paths:
           content: {}
         404:
           description: System security plan or implemented requirement not found
+          content: {}
+        409:
+          description: Conflict with current state
           content: {}
       security:
         - oscal_auth:
@@ -2064,6 +2111,9 @@ paths:
           content: {}
         405:
           description: Validation exception
+          content: {}
+        409:
+          description: Conflict with current state
           content: {}
       security:
         - oscal_auth:


### PR DESCRIPTION
This adds conflict HTTP status under `PATCH` and `PUT` operations.
I was unsure how to know the cause of the conflict so the message
for each conflict status says "Conflict with current state." If
there is anything I can look at to know how to make the message
better/more specific please let me know.

Closes #50 