### PR TITLE
Update link to handling uuids documentation

### DIFF
--- a/docs/handling-uuids-on-post-put.md
+++ b/docs/handling-uuids-on-post-put.md
@@ -13,7 +13,7 @@ graph LR
 
 When creating new objects, `POST` is the preferred option. The UUID of the new object
 does not need to be specified, so `POST` should be used when there is no UUID preference.
-If the UUID is specified in the body, an HTTP 4xx error will be returned.
+If the UUID is specified in the body, an HTTP 409 error will be returned.
 
 ### Making a `POST` request
 
@@ -30,7 +30,7 @@ When creating new objects, `PUT` should only be used when there is a preferred v
 the UUID. Additionally, it can be used to update an existing object by replacing its entire
 definition with an updated version. Currently, `PUT` is defined to include the UUID in the
 request path and the request body, but it is not necessary to specify the UUID in the body.
-If provided, the UUID in the body must match the UUID in the path, or else an HTTP 4xx
+If provided, the UUID in the body must match the UUID in the path, or else an HTTP 409
 error will be returned. If an object with the specified UUID exists, the `PUT` request will
 update the existing object. If no objects with the specified UUID exist, a new object will
 be created with the provided UUID.

--- a/docs/handling-uuids-on-post-put.md
+++ b/docs/handling-uuids-on-post-put.md
@@ -1,0 +1,53 @@
+# Handling UUIDs in `POST` and `PUT` operations
+
+## `POST`
+
+When creating new objects, `POST` is the preferred option. The UUID of the object does
+not need to be specified, so `POST` should be used when there is not a preferred UUID
+for the new object. If the UUID is specified in the body, an HTTP 4xx error will be returned.
+
+## `PUT`
+
+When creating new objects, `PUT` should only be used when a specific UUID is required.
+Additionally, it can be used to update an object by replacing its entire definition with
+ an updated version. Currently, `PUT` is defined to include the UUID in the request path
+ and the request body, however it is not necessary to specify the UUID in the body. If the
+ UUID is specified in both the path and the body, the UUID must match, or else an HTTP 4xx
+ error will be returned. If an object with the specified UUID exists, the `PUT` request will
+ update the existing object. If no objects exist with the specified UUID, a new object will
+ be created with that UUID.
+
+## Diagrams
+
+### `PUT` vs `POST`
+
+```mermaid
+graph LR
+  Init([Make a request]) --> Pref{Preference on UUID}
+  Pref -->|Yes| PUT
+  Pref -->|No| POST
+```
+
+### Making a `POST` request
+
+```mermaid
+graph LR
+  POST([POST]) --> UUID{Is UUID specified in body}
+  UUID -->|Yes| Error([Error])
+  UUID -->|No| Z[Create new resource<br/>and generate UUID]
+```
+
+### Making a `PUT` request
+
+```mermaid
+graph LR
+  PUT([PUT]) --> UUID{Is UUID specified in body}
+  UUID -->|No| Exist
+  UUID -->|Yes| UUIDMatch
+  UUIDMatch{Does the body UUID<br/>match path UUID}
+  UUIDMatch -->|No| Error([Error])
+  UUIDMatch -->|Yes| Exist
+  Exist{Does a resource with the<br/>UUID already exist}
+  Exist -->|Yes| Update[Update matching resource]
+  Exist -->|No| Create[Create new resource<br/>with given UUID]
+```

--- a/docs/handling-uuids-on-post-put.md
+++ b/docs/handling-uuids-on-post-put.md
@@ -2,20 +2,20 @@
 
 ## `POST`
 
-When creating new objects, `POST` is the preferred option. The UUID of the object does
-not need to be specified, so `POST` should be used when there is not a preferred UUID
-for the new object. If the UUID is specified in the body, an HTTP 4xx error will be returned.
+When creating new objects, `POST` is the preferred option. The UUID of the new object
+does not need to be specified, so `POST` should be used when there is no UUID preference.
+If the UUID is specified in the body, an HTTP 4xx error will be returned.
 
 ## `PUT`
 
-When creating new objects, `PUT` should only be used when a specific UUID is required.
-Additionally, it can be used to update an object by replacing its entire definition with
- an updated version. Currently, `PUT` is defined to include the UUID in the request path
- and the request body, however it is not necessary to specify the UUID in the body. If the
- UUID is specified in both the path and the body, the UUID must match, or else an HTTP 4xx
- error will be returned. If an object with the specified UUID exists, the `PUT` request will
- update the existing object. If no objects exist with the specified UUID, a new object will
- be created with that UUID.
+When creating new objects, `PUT` should only be used when there is a preferred value for
+the UUID. Additionally, it can be used to update an existing object by replacing its entire
+definition with an updated version. Currently, `PUT` is defined to include the UUID in the
+request path and the request body, but it is not necessary to specify the UUID in the body.
+If provided, the UUID in the body must match the UUID in the path, or else an HTTP 4xx
+error will be returned. If an object with the specified UUID exists, the `PUT` request will
+update the existing object. If no objects with the specified UUID exist, a new object will
+be created with the provided UUID.
 
 ## Diagrams
 

--- a/docs/handling-uuids-on-post-put.md
+++ b/docs/handling-uuids-on-post-put.md
@@ -1,6 +1,6 @@
 # Handling UUIDs in `POST` and `PUT` operations
 
-##  `PUT` vs `POST`
+## `PUT` vs `POST`
 
 ```mermaid
 graph LR

--- a/docs/handling-uuids-on-post-put.md
+++ b/docs/handling-uuids-on-post-put.md
@@ -1,10 +1,28 @@
 # Handling UUIDs in `POST` and `PUT` operations
 
+##  `PUT` vs `POST`
+
+```mermaid
+graph LR
+  Init([Make a request]) --> Pref{Preference on UUID}
+  Pref -->|Yes| PUT
+  Pref -->|No| POST
+```
+
 ## `POST`
 
 When creating new objects, `POST` is the preferred option. The UUID of the new object
 does not need to be specified, so `POST` should be used when there is no UUID preference.
 If the UUID is specified in the body, an HTTP 4xx error will be returned.
+
+### Making a `POST` request
+
+```mermaid
+graph LR
+  POST([POST]) --> UUID{Is UUID specified in body}
+  UUID -->|Yes| Error([Error])
+  UUID -->|No| Z[Create new resource<br/>and generate UUID]
+```
 
 ## `PUT`
 
@@ -16,26 +34,6 @@ If provided, the UUID in the body must match the UUID in the path, or else an HT
 error will be returned. If an object with the specified UUID exists, the `PUT` request will
 update the existing object. If no objects with the specified UUID exist, a new object will
 be created with the provided UUID.
-
-## Diagrams
-
-### `PUT` vs `POST`
-
-```mermaid
-graph LR
-  Init([Make a request]) --> Pref{Preference on UUID}
-  Pref -->|Yes| PUT
-  Pref -->|No| POST
-```
-
-### Making a `POST` request
-
-```mermaid
-graph LR
-  POST([POST]) --> UUID{Is UUID specified in body}
-  UUID -->|Yes| Error([Error])
-  UUID -->|No| Z[Create new resource<br/>and generate UUID]
-```
 
 ### Making a `PUT` request
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -76,7 +76,7 @@ info:
     </details>
 
     For guidance on handling UUIDs in `POST' and 'PUT' operations, please review [handling-uuids-on-post-put.md]
-    (https://github.com/EasyDynamics/oscal-rest/blob/feature/guidance-on-post-put/docs/handling-uuids-on-post-put.md).
+    (https://github.com/EasyDynamics/oscal-rest/blob/develop/docs/handling-uuids-on-post-put.md).
   contact:
     email: info@easydynamics.com
   version: 0.1.0

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -73,6 +73,9 @@ info:
       fields will remain the same. The list of revisions will still contain its previous items,
       along with the new version item.
     </details>
+
+    For guidance on handling UUIDs in `POST' and 'PUT' operations, please review [handling-uuids-on-post-put.md]
+    (https://github.com/EasyDynamics/oscal-rest/blob/feature/guidance-on-post-put/docs/handling-uuids-on-post-put.md).
   contact:
     email: info@easydynamics.com
   version: 0.1.0


### PR DESCRIPTION
Currently when a user clicks the link to 
handling-uuids-on-post-put.md in openapi.yaml,
it brings them to the page on the 
feature/guidance-on-post-put branch. This update will
now keep them on the develop branch.
