### PR TITLE
Fix minor errors in `PUT`/`POST` documentation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -75,8 +75,8 @@ info:
       along with the new version item.
     </details>
 
-    For guidance on handling UUIDs in `POST' and 'PUT' operations, please review [handling-uuids-on-post-put.md]
-    (https://github.com/EasyDynamics/oscal-rest/blob/develop/docs/handling-uuids-on-post-put.md).
+    For guidance on handling UUIDs in `POST` and `PUT` operations, please review
+    [handling-uuids-on-post-put.md](https://github.com/EasyDynamics/oscal-rest/blob/develop/docs/handling-uuids-on-post-put.md).
   contact:
     email: info@easydynamics.com
   version: 0.1.0


### PR DESCRIPTION
This fixes minor errors that were noticed during the most recent sprint demo. POST and PUT are now shown as `POST` and `PUT`. It also fixes the link to documentation so it now works properly.
