### PR TITLE
Add GET operation to API base path

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -119,6 +119,20 @@ tags:
       description: Find out more
       url: https://pages.nist.gov/OSCAL/concepts/layer/assessment/assessment-results/
 paths:
+  /:
+    get:
+      summary: Returns the currently running API version.
+      operationId: getAPIInfo
+      responses:
+        200:
+          description: successful operation
+          content:
+            schema:
+              type: object
+              properties:
+                version:
+                  type: string
+                  format: binary
   /catalogs:
     get:
       tags:


### PR DESCRIPTION
Any request to the base path of the api currently returns an error
message, which seems a bit unfriendly to me. There are certainly
use-cases where I simply want to know whether the API at a given
endpoint is the API that I expect, or even what version of the API is
being used. This change introduces an extremely simple GET operation on
the base bath of the API that currently returns just the version of the
API. It can be augmented to return additional data, but version seems
like a good starting point. This endpoint may make a great candidate
for an initial health-check of the running API.
