### PR TITLE
fix: errors are shown when viewing in Swagger Editor

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -245,6 +245,7 @@ paths:
           description: ID of catalog to replace
           schema:
             type: string
+          required: true
       requestBody:
         description: Catalog object to be replaced
         content:
@@ -2517,7 +2518,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OSCALassessmentPlans"
+              $ref: "#/components/schemas/OSCALAssessmentPlan"
         required: true
       responses:
         200:


### PR DESCRIPTION
Path parameters are always required and therefore should be marked as
such. Additionally, there was a typo in the schema information for the
replacement of assessment plan objects.
