### PR TITLE
changed version 0.2.0 to 0.2.1

### DIFF
--- a/basicRestapi.yaml
+++ b/basicRestapi.yaml
@@ -36,7 +36,7 @@ info:
 
   contact:
     email: oscal@oscal.io
-  version: 0.2.0
+  version: 0.2.1
 externalDocs:
   description: Find out more about OSCAL
   url: https://pages.nist.gov/OSCAL


### PR DESCRIPTION
The Swagger capability I'm using to publish the REST API specification requires the version number be incremented. In fairness, this is a minor update to the 0.2.0 version we published a few month ago. Thus I am changing the version to 0.2.1 in the `basicRestapi.yaml` file.