### PR TITLE
see #104 Fixed all issues in Swagger Editor and issue 104.

### DIFF
--- a/OSCALRestOpenAPI.json
+++ b/OSCALRestOpenAPI.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.9",
+  "openapi": "3.0.3",
   "info": {
     "title": "OSCAL REST",
     "description": "This is an open-source REST API specification for exchanging [OSCAL](https://pages.nist.gov/OSCAL/) content between tools and organizations.\n\nThe _OSCAL REST OpenAPI Specification_ addresses OSCAL XML, JSON and YAML content for all seven OSCAL models. Each OSCAL model has a primary set of REST API methods and endpoints for the OSCAL content itself, as well as methods and endpoints for snapshots and attachments. OSCAL profiles also have methods and endpoints for live profile resolution and snapshots of resolved profiles.\n\nFor an overview and more information, visit [https://docs.oscal.io/docs/oscal-rest-openapi](https://docs.oscal.io/docs/oscal-rest-openapi)\n\n---\n\n**Known-Issue: OSCAL XML Representation**\n\nThere is a [known-issue](https://github.com/OAI/OpenAPI-Specification/issues/630) that prevents proper expression of OSCAL XML in OpenAPI.\n\nWhen the specification calls for OSCAL content to be accepted or returned, the content must be fully OSCAL valid. Even if the specification shows a non-compliant schema or example.",

--- a/OSCALRestOpenAPI.json
+++ b/OSCALRestOpenAPI.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.0",
+  "openapi": "3.1.1",
   "info": {
     "title": "OSCAL REST",
     "description": "This is an open-source REST API specification for exchanging [OSCAL](https://pages.nist.gov/OSCAL/) content between tools and organizations.\n\nThe _OSCAL REST OpenAPI Specification_ addresses OSCAL XML, JSON and YAML content for all seven OSCAL models. Each OSCAL model has a primary set of REST API methods and endpoints for the OSCAL content itself, as well as methods and endpoints for snapshots and attachments. OSCAL profiles also have methods and endpoints for live profile resolution and snapshots of resolved profiles.\n\nFor an overview and more information, visit [https://docs.oscal.io/docs/oscal-rest-openapi](https://docs.oscal.io/docs/oscal-rest-openapi)\n\n---\n\n**Known-Issue: OSCAL XML Representation**\n\nThere is a [known-issue](https://github.com/OAI/OpenAPI-Specification/issues/630) that prevents proper expression of OSCAL XML in OpenAPI.\n\nWhen the specification calls for OSCAL content to be accepted or returned, the content must be fully OSCAL valid. Even if the specification shows a non-compliant schema or example.",
@@ -21,6 +21,9 @@
   "servers": [
     {
       "url": "http://localhost:8080/oscal/v1"
+    },
+    {
+      "url": "https://raw.githubusercontent.com/"
     }
   ],
   "tags": [
@@ -1682,15 +1685,6 @@
                 "schema": {
                   "$ref": "#/components/schemas/OSCALErrorMessage"
                 }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OSCALSnapshotAttributes"
               }
             }
           }
@@ -14355,7 +14349,7 @@
           },
           "snapshot": {
             "type": "object",
-            "ref$" : "#components/schemas/OSCALSnapshotAttributes"
+            "$ref" : "#components/schemas/OSCALSnapshotAttributes"
           }
         }
       },

--- a/OSCALRestOpenAPI.json
+++ b/OSCALRestOpenAPI.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.1",
+  "openapi": "3.0.9",
   "info": {
     "title": "OSCAL REST",
     "description": "This is an open-source REST API specification for exchanging [OSCAL](https://pages.nist.gov/OSCAL/) content between tools and organizations.\n\nThe _OSCAL REST OpenAPI Specification_ addresses OSCAL XML, JSON and YAML content for all seven OSCAL models. Each OSCAL model has a primary set of REST API methods and endpoints for the OSCAL content itself, as well as methods and endpoints for snapshots and attachments. OSCAL profiles also have methods and endpoints for live profile resolution and snapshots of resolved profiles.\n\nFor an overview and more information, visit [https://docs.oscal.io/docs/oscal-rest-openapi](https://docs.oscal.io/docs/oscal-rest-openapi)\n\n---\n\n**Known-Issue: OSCAL XML Representation**\n\nThere is a [known-issue](https://github.com/OAI/OpenAPI-Specification/issues/630) that prevents proper expression of OSCAL XML in OpenAPI.\n\nWhen the specification calls for OSCAL content to be accepted or returned, the content must be fully OSCAL valid. Even if the specification shows a non-compliant schema or example.",
@@ -14349,7 +14349,7 @@
           },
           "snapshot": {
             "type": "object",
-            "$ref" : "#components/schemas/OSCALSnapshotAttributes"
+            "$ref" : "#/components/schemas/OSCALSnapshotAttributes"
           }
         }
       },


### PR DESCRIPTION

**Swagger Editor Issues:**
1. When I opened the file in Swagger Editor, I noticed three errors in the inspector.
   - The first error was resolved by changing the `openapi` version from `3.1.0` to `3.0.0` or `3.1.1`. If you want to keep version `3.1.0`, it needs to be updated to `3.1.1`. According to the official OpenAPI documentation, there's no difference between the two versions.
   - The second error was a semantic issue: **GET operations cannot have a requestBody.** I fixed this by removing the requestBody in line 1688.
   - The third issue was a structural error: **additionalProperty: ref$**. I corrected this by changing `ref$` to `$ref` in line 14355.

**Issue 104:**
In OpenAPI, external URLs should be approved for reference. To meet this requirement, I added `https://raw.githubusercontent.com` to the servers section of the specification at line 25.
